### PR TITLE
Use highest block header from storage when refreshing the contract runtime

### DIFF
--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -446,12 +446,12 @@ impl MainReactor {
         // only marked complete after we receive enough signatures from validators.  Using the
         // highest stored block ensures the ContractRuntime's `exec_queue` isn't set to a block
         // height we already executed but haven't yet marked complete.
-        match self.storage.read_highest_block() {
-            Ok(Some(block)) => {
-                let block_height = block.height();
-                let state_root_hash = block.state_root_hash();
-                let block_hash = block.id();
-                let accumulated_seed = block.header().accumulated_seed();
+        match self.storage.read_highest_block_header() {
+            Ok(Some(block_header)) => {
+                let block_height = block_header.height();
+                let state_root_hash = block_header.state_root_hash();
+                let block_hash = block_header.id();
+                let accumulated_seed = block_header.accumulated_seed();
                 self.initialize_contract_runtime(
                     block_height + 1,
                     *state_root_hash,


### PR DESCRIPTION
We may receive block headers that we don't have the body for in a SyncLeap. Since the header will be added in storage and to the height index, `read_highest_block` will return `Ok(None)` if it is called just after the SyncLeap and before getting the body. This will prevent the contract runtime to be correctly initialized, making it stall execution of subsequent blocks.
Fix this by using the highest block header instead of the highest block from storage while refreshing the contract runtime.

Co-authored-by: George Pisaltu <georgep@casperlabs.io>
Signed-off-by: Alexandru Sardan <alexandru@casperlabs.io>